### PR TITLE
Fix creating metric name lookup maps for endpoints with a prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ An example of how to add Duckula powered routes to an existing Compojure-based a
 
 ```
 
+# Changelog
+
+
+## [0.5.1] - 2019-12-26
+
+*Unreleased*
+
+Bug fix release - fixes an issue with metrics reporting for namespaced routes. Available as `0.5.1-SNAPSHOT`
+
+## [0.5.0] - 2019-10-23
+
+Initial public release
+
 # Authors
 
 <sup>In alphabetical order</sup>

--- a/project.clj
+++ b/project.clj
@@ -1,17 +1,17 @@
-(defproject nomnom/duckula "0.5.0-SNAPSHOT"
+(defproject nomnom/duckula "0.5.1-SNAPSHOT"
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.stuartsierra/component "0.4.0"]
-                 [nomnom/abracad "0.5.0"]]
+                 [nomnom/abracad "0.5.1"]]
   :deploy-repositories {"clojars" {:sign-releases false
-                                   :username [:gpg :env/clojars_username]
-                                   :password [:gpg :env/clojars_password]}}
+                                   :username :env/clojars_username
+                                   :password :env/clojars_password}}
   :license {:name "MIT License"
             :url "https://opensource.org/licenses/MIT"
             :year 2018
             :key "mit"}
-  :plugins [[lein-cloverage "1.0.13" :exclusions [org.clojure/clojure]]]
+  :plugins [[lein-cloverage "1.1.2" :exclusions [org.clojure/clojure]]]
 
   :profiles {:dev
              {:resource-paths ["dev-resources"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/duckula "0.5.0"
+(defproject nomnom/duckula "0.5.0-SNAPSHOT"
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/src/duckula/handler.clj
+++ b/src/duckula/handler.clj
@@ -32,18 +32,17 @@
   test-api.some.endpoint.success
   test-api.some.endpoint.error
   test-api.some.endpoint.failure"
-  [config]
-  (->> config
-       :endpoints
+  [{:keys [endpoints prefix] :as config}]
+  (->> endpoints
        (map (fn [[path _conf]]
               (let [metric-key (str (:name config) (s/replace path \/ \.))
                     success-key (str metric-key ".success")
                     error-key (str metric-key ".error")
                     failure-key (str metric-key ".failure")]
-                (hash-map path [metric-key
-                                success-key
-                                error-key
-                                failure-key]))))
+                (hash-map (str prefix path) [metric-key
+                                             success-key
+                                             error-key
+                                             failure-key]))))
        (into {})))
 
 (def not-found-metrics

--- a/src/duckula/handler.clj
+++ b/src/duckula/handler.clj
@@ -35,7 +35,7 @@
   [{:keys [endpoints prefix] :as config}]
   (->> endpoints
        (map (fn [[path _conf]]
-              (let [metric-key (str (:name config) (s/replace path \/ \.))
+              (let [metric-key (str (:name config) (s/replace (str prefix path) \/ \.))
                     success-key (str metric-key ".success")
                     error-key (str metric-key ".error")
                     failure-key (str metric-key ".failure")]

--- a/test/duckula/handler_test.clj
+++ b/test/duckula/handler_test.clj
@@ -4,17 +4,31 @@
             [duckula.handler :as handler]))
 
 (deftest metric-keys
-  (is (= {"/bar/baz/ok-how-about-this" ["foo.bar.baz.ok-how-about-this"
-                                        "foo.bar.baz.ok-how-about-this.success"
-                                        "foo.bar.baz.ok-how-about-this.error"
-                                        "foo.bar.baz.ok-how-about-this.failure"]
-          "/one/two/three" ["foo.one.two.three"
-                            "foo.one.two.three.success"
-                            "foo.one.two.three.error"
-                            "foo.one.two.three.failure"]}
-         (handler/build-metric-keys {:name "foo"
-                                     :endpoints {"/one/two/three" {:handler (fn [])}
-                                                 "/bar/baz/ok-how-about-this" {:handler (fn [])}}}))))
+  (testing "regular case"
+    (is (= {"/bar/baz/ok-how-about-this" ["foo.bar.baz.ok-how-about-this"
+                                          "foo.bar.baz.ok-how-about-this.success"
+                                          "foo.bar.baz.ok-how-about-this.error"
+                                          "foo.bar.baz.ok-how-about-this.failure"]
+            "/one/two/three" ["foo.one.two.three"
+                              "foo.one.two.three.success"
+                              "foo.one.two.three.error"
+                              "foo.one.two.three.failure"]}
+           (handler/build-metric-keys {:name "foo"
+                                       :endpoints {"/one/two/three" {:handler (fn [])}
+                                                   "/bar/baz/ok-how-about-this" {:handler (fn [])}}}))))
+  (testing "with prefix"
+    (is (= {"/api/bar/baz/ok-how-about-this" ["foo.bar.baz.ok-how-about-this"
+                                          "foo.bar.baz.ok-how-about-this.success"
+                                          "foo.bar.baz.ok-how-about-this.error"
+                                          "foo.bar.baz.ok-how-about-this.failure"]
+            "/api/one/two/three" ["foo.one.two.three"
+                                  "foo.one.two.three.success"
+                                  "foo.one.two.three.error"
+                                  "foo.one.two.three.failure"]}
+           (handler/build-metric-keys {:name "foo"
+                                       :prefix "/api"
+                                       :endpoints {"/one/two/three" {:handler (fn [])}
+                                                   "/bar/baz/ok-how-about-this" {:handler (fn [])}}})))))
 
 (deftest route-map-builder
   (let [search-handler (fn [])

--- a/test/duckula/handler_test.clj
+++ b/test/duckula/handler_test.clj
@@ -17,14 +17,14 @@
                                        :endpoints {"/one/two/three" {:handler (fn [])}
                                                    "/bar/baz/ok-how-about-this" {:handler (fn [])}}}))))
   (testing "with prefix"
-    (is (= {"/api/bar/baz/ok-how-about-this" ["foo.bar.baz.ok-how-about-this"
-                                          "foo.bar.baz.ok-how-about-this.success"
-                                          "foo.bar.baz.ok-how-about-this.error"
-                                          "foo.bar.baz.ok-how-about-this.failure"]
-            "/api/one/two/three" ["foo.one.two.three"
-                                  "foo.one.two.three.success"
-                                  "foo.one.two.three.error"
-                                  "foo.one.two.three.failure"]}
+    (is (= {"/api/bar/baz/ok-how-about-this" ["foo.api.bar.baz.ok-how-about-this"
+                                              "foo.api.bar.baz.ok-how-about-this.success"
+                                              "foo.api.bar.baz.ok-how-about-this.error"
+                                              "foo.api.bar.baz.ok-how-about-this.failure"]
+            "/api/one/two/three" ["foo.api.one.two.three"
+                                  "foo.api.one.two.three.success"
+                                  "foo.api.one.two.three.error"
+                                  "foo.api.one.two.three.failure"]}
            (handler/build-metric-keys {:name "foo"
                                        :prefix "/api"
                                        :endpoints {"/one/two/three" {:handler (fn [])}


### PR DESCRIPTION
If a handler config has a prefix setting, the generated metric keys wouldn't be generated correctly. 
For example:

```clojure
{ :prefix "/api"
  :name "bananas"
  :endpoints  { "/test" :handler .... } }
```

Would lookup metric keys by "/test" not "/api/test" resulting in lots of "not-found" routes being logged. 

In default operation (no prefix) metric keys are generated and used as expected.