### PR TITLE
Generate Swagger/OpenAPI documentation and fix JSON handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/deps.txt
+/.lsp/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# duckula
+# Duckula
 
 
 Status

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Then in your Component system:
   (merge
    {:db (some.db/connection)
     ;; required for metrics and error reporting
-    :monitoring duckula.component.basic-monitoring/BasicMonitoring}
+    :monitoring duckula.component.basic-monitoring/basic}
    ;; see dev-resources dir for a working example
    ;; at the very least, your ring middleware stack needs to handle
    ;; JSON parsing from the POST body
@@ -167,7 +167,7 @@ See it here: https://github.com/nomnom-insights/nomnom.duckula.monitoring
   "Test HTTP server"
   (:require [duckula.test.component.http-server :as http-server]
             duckula.handler
-            [duckula.component.basic-monitoring :as monit]
+            [duckula.component.basic-monitoring :as monitoring]
             [duckula.handler.echo :as handler.echo]
             [duckula.handler.number :as handler.number]
             [duckula.handler.search :as handler.search]
@@ -194,7 +194,7 @@ See it here: https://github.com/nomnom-insights/nomnom.duckula.monitoring
 (defn start! []
   (let [sys (component/map->SystemMap
              (merge
-              {:monitoring monit/BasicMonitoring}
+              {:monitoring monitoring/basic}
               (http-server/create (duckula.handler/build config)
                                   [:monitoring]
                                   {:name "test-rpc-server"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Duckula is a synchronous equivalent of [Bunnicula](https://github.com/nomnom-ins
 
 ## Roadmap
 
+- [x] exposes (optionally) endpoint with API documentation based on Avro's doc properites (schemas and schema fields can be documented) in the Swagger/OpenAPI format
 - [ ] can talk Avro (input and output) via content type negotiation
-- [ ] exposes (optionally) endpoint with API documentation based on Avro's doc properites (schemas and schema fields can be documented) in the OpenAPI format
+
 - [ ] equivalent clj-http middleware for building type-safe clients
 
 ## Rationale
@@ -263,6 +264,10 @@ The UI is now accessible under `/~docs/ui` and the API definition can be downloa
 
 
 # Changelog
+
+## [0.6.0-SNAPSHOT] - **Unreleased**
+
+Adds [Swagger](https://swagger.io) support, allows for defining inline Avro schemas in the API config and ships witha minimal Ring middleware for handling JSON requests.
 
 ## [0.5.3] - 2020-03-25
 

--- a/dev-resources/api.restclient
+++ b/dev-resources/api.restclient
@@ -32,3 +32,8 @@ POST http://localhost:3003/echo
 Content-type: application/json
 accept: application/json
 { "input" : "20" }
+
+# swagger get?
+GET http://localhost:3003/~docs/ui
+
+#swagger.json

--- a/dev-resources/duckula/test/component/http_server.clj
+++ b/dev-resources/duckula/test/component/http_server.clj
@@ -1,29 +1,40 @@
 (ns duckula.test.component.http-server
   (:require
-   [com.stuartsierra.component :as component]
-   [ring.component.jetty :as jetty]
-   [ring.middleware.params :as params]
-   [ring.middleware.json :as ring-json]
-   [ring.middleware.defaults :as ring-defaults]))
+    [com.stuartsierra.component :as component]
+    [ring.component.jetty :as jetty]))
 
-(defn wrap-handler [handler-fn]
-  (-> handler-fn
-      (ring-json/wrap-json-body {:keywords? true})
-      params/wrap-params
-      (ring-defaults/wrap-defaults ring-defaults/api-defaults)))
 
-(defrecord Handler [handler-fn]
+(defrecord Handler
+  [handler-fn]
+
   component/Lifecycle
-  (start [this]
-    (let [handler (wrap-handler handler-fn)]
+
+  (start
+    [this]
+    (let [handler (:handler-fn this)]
       (assoc this :handler (fn [req]
                              (handler (assoc req :component this))))))
+
+
   (stop [this] (assoc this :handler nil)))
 
-(defn create [handler-fn dependencies conf]
+
+(defn create-handler
+  [handler-fn]
+  (map->Handler
+    {:handler-fn handler-fn}))
+
+
+(defn create-server
+  [conf]
+  (jetty/jetty-server conf))
+
+
+(defn create
+  [handler-fn dependencies conf]
   (let [handler-key (keyword (:name conf) "handler")
         server-key (keyword (:name conf) "server")]
-    {handler-key (component/using (map->Handler {:handler-fn handler-fn})
+    {handler-key (component/using (create-handler handler-fn)
                                   dependencies)
-     server-key (component/using (jetty/jetty-server conf)
+     server-key (component/using (create-server conf)
                                  {:app handler-key})}))

--- a/dev-resources/duckula/test/handler/echo.clj
+++ b/dev-resources/duckula/test/handler/echo.clj
@@ -1,5 +1,6 @@
 (ns duckula.test.handler.echo)
 
+
 (defn handler
   "No validation, echoes whatever"
   [req]

--- a/dev-resources/duckula/test/handler/number.clj
+++ b/dev-resources/duckula/test/handler/number.clj
@@ -1,5 +1,6 @@
 (ns duckula.test.handler.number)
 
+
 (defn handler
   [{:keys [body] :as req}]
   (let [{:keys [input]} body]

--- a/dev-resources/duckula/test/handler/search.clj
+++ b/dev-resources/duckula/test/handler/search.clj
@@ -1,5 +1,6 @@
 (ns duckula.test.handler.search)
 
+
 (defn handler
   [{:keys [body] :as req}]
   (let [{:keys [query order_by size]} body] ;; TestRequest!

--- a/dev-resources/duckula/test/server.clj
+++ b/dev-resources/duckula/test/server.clj
@@ -30,7 +30,7 @@
 (defn start-with-handler! [handler]
   (let [sys (component/map->SystemMap
              (merge
-              {:monitoring monitoring/BasicMonitoring}
+              {:monitoring monitoring/basic}
               (http-server/create handler
                                   [:monitoring]
                                   {:name "test-rpc-server"

--- a/dev-resources/duckula/test/server.clj
+++ b/dev-resources/duckula/test/server.clj
@@ -3,6 +3,7 @@
   (:require [duckula.test.component.http-server :as http-server]
             duckula.handler
             duckula.swagger
+            duckula.middleware
             [duckula.component.basic-monitoring :as monitoring]
             [duckula.test.handler.echo :as handler.echo]
             [duckula.test.handler.number :as handler.number]
@@ -39,7 +40,7 @@
     (reset! server (component/start sys))))
 
 (defn start! []
-  (start-with-handler! (duckula.swagger/with-docs config)))
+  (start-with-handler! (duckula.middleware/wrap-handler (duckula.swagger/with-docs config))))
 
 (defn stop! []
   (swap! server component/stop))

--- a/dev-resources/duckula/test/server.clj
+++ b/dev-resources/duckula/test/server.clj
@@ -2,6 +2,7 @@
   "Test HTTP server"
   (:require [duckula.test.component.http-server :as http-server]
             duckula.handler
+            duckula.swagger
             [duckula.component.basic-monitoring :as monitoring]
             [duckula.test.handler.echo :as handler.echo]
             [duckula.test.handler.number :as handler.number]
@@ -38,7 +39,7 @@
     (reset! server (component/start sys))))
 
 (defn start! []
-  (start-with-handler! (duckula.handler/build config)))
+  (start-with-handler! (duckula.swagger/with-docs config)))
 
 (defn stop! []
   (swap! server component/stop))

--- a/dev-resources/duckula/test/server.clj
+++ b/dev-resources/duckula/test/server.clj
@@ -1,16 +1,19 @@
 (ns duckula.test.server
   "Test HTTP server"
-  (:require [duckula.test.component.http-server :as http-server]
-            duckula.handler
-            duckula.swagger
-            duckula.middleware
-            [duckula.component.basic-monitoring :as monitoring]
-            [duckula.test.handler.echo :as handler.echo]
-            [duckula.test.handler.number :as handler.number]
-            [duckula.test.handler.search :as handler.search]
-            [com.stuartsierra.component :as component]))
+  (:require
+    [com.stuartsierra.component :as component]
+    [duckula.component.basic-monitoring :as monitoring]
+    [duckula.handler]
+    [duckula.middleware]
+    [duckula.swagger]
+    [duckula.test.component.http-server :as http-server]
+    [duckula.test.handler.echo :as handler.echo]
+    [duckula.test.handler.number :as handler.number]
+    [duckula.test.handler.search :as handler.search]))
+
 
 (def server (atom nil))
+
 
 (def config
   {:name "test-server-rpc"
@@ -29,18 +32,21 @@
                ;; no validation
                "/echo" {:handler handler.echo/handler}}})
 
+
 (defn start-with-handler! [handler]
   (let [sys (component/map->SystemMap
-             (merge
-              {:monitoring monitoring/basic}
-              (http-server/create handler
-                                  [:monitoring]
-                                  {:name "test-rpc-server"
-                                   :port 3003})))]
+              (merge
+                {:monitoring monitoring/basic}
+                (http-server/create handler
+                                    [:monitoring]
+                                    {:name "test-rpc-server"
+                                     :port 3003})))]
     (reset! server (component/start sys))))
+
 
 (defn start! []
   (start-with-handler! (duckula.middleware/wrap-handler (duckula.swagger/with-docs config))))
+
 
 (defn stop! []
   (swap! server component/stop))

--- a/dev-resources/schema/endpoint/number/multiply/Response.avsc
+++ b/dev-resources/schema/endpoint/number/multiply/Response.avsc
@@ -1,5 +1,5 @@
 {
-  "name": "number.multiply.Responses",
+  "name": "number.multiply.Response",
   "type": "record",
   "fields": [
     {

--- a/dev-resources/schema/endpoint/search/get/Response.avsc
+++ b/dev-resources/schema/endpoint/search/get/Response.avsc
@@ -5,6 +5,7 @@
   "fields": [
     {
       "name": "id",
+      "doc" : "ID of the document",
       "type": "string"
     },
     {

--- a/dev-resources/schema/endpoint/search/get/Response.avsc
+++ b/dev-resources/schema/endpoint/search/get/Response.avsc
@@ -1,6 +1,7 @@
 {
   "name": "search.get.Response",
   "type": "record",
+  "doc" : "Returns search results, along with ids and tags",
   "fields": [
     {
       "name": "id",

--- a/dev-resources/schema/endpoint/search/test/Request.avsc
+++ b/dev-resources/schema/endpoint/search/test/Request.avsc
@@ -1,6 +1,7 @@
 {
   "name": "search.test.Request",
   "type": "record",
+  "doc" : "Find all matching documents and specify the order",
   "fields": [
     {
       "name": "query",

--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,12 @@
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.stuartsierra/component "0.4.0"]
+                 [com.stuartsierra/component "1.0.0"]
                  [nomnom/abracad "0.5.1"]
+
+                 [ring/ring-defaults "0.3.2"]
+                 [ring/ring-json "0.5.0"]
+
 
                  ;; Dependencies for swagger schema generators
                  ;; and visualizing things
@@ -24,15 +28,13 @@
               :global-vars {*warn-on-reflection* true}
               :dependencies [[org.clojure/tools.logging "1.1.0"]
                              [ch.qos.logback/logback-classic "1.2.3"
-                  :exclusions [org.slf4j/slf4j-api]]
+                              :exclusions [org.slf4j/slf4j-api]]
                              ;; test & dev deps
-                             [clj-http "3.10.0"]
+                             [clj-http "3.10.1"]
                              [ring-jetty-component "0.3.1"
                               :exclude [ring/ring-codec
                                         org.eclipse.jetty/jetty-server]]
                              [org.eclipse.jetty/jetty-server "9.4.21.v20190926"]
-                             [ring/ring-defaults "0.3.2"]
-                             [ring/ring-json "0.5.0"]
                              [compojure "1.6.1"]
                              [ring/ring-mock "0.4.0"
                               :exclusions [ring/ring-codec]]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/duckula "0.5.3"
+(defproject nomnom/duckula "0.6.0-SNAPSHOT"
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/duckula "0.7.0-SNAPSHOT"
+(defproject nomnom/duckula "0.7.1-SNAPSHOT"
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,11 @@
                  [com.stuartsierra/component "0.4.0"]
                  [nomnom/abracad "0.5.1"]
 
-                 ;; hmmm
+                 ;; Dependencies for swagger schema generators
+                 ;; and visualizing things
                  [prismatic/schema "1.1.12"]
-                 [metosin/ring-swagger "0.26.2"]]
+                 [metosin/ring-swagger "0.26.2"]
+                 [metosin/ring-swagger-ui "3.25.3"]]
   :deploy-repositories {"clojars" {:sign-releases false
                                    :username :env/clojars_username
                                    :password :env/clojars_password}}

--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,8 @@
                  [com.stuartsierra/component "0.4.0"]
                  [nomnom/abracad "0.5.1"]
 
-                 ;; doc generator
-                 [cddr/integrity "0.3.0-SNAPSHOT"
-                  :exclusions [com.damballa/abracad org.clojure/clojure]]
+                 ;; hmmm
+                 [prismatic/schema "1.1.12"]
                  [metosin/ring-swagger "0.26.2"]]
   :deploy-repositories {"clojars" {:sign-releases false
                                    :username :env/clojars_username
@@ -24,7 +23,8 @@
                              ;; test & dev deps
                              [clj-http "3.10.0"]
                              [ring-jetty-component "0.3.1"
-                              :exclude [org.eclipse.jetty/jetty-server]]
+                              :exclude [ring/ring-codec
+                                        org.eclipse.jetty/jetty-server]]
                              [org.eclipse.jetty/jetty-server "9.4.21.v20190926"]
                              [ring/ring-defaults "0.3.2"]
                              [ring/ring-json "0.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,12 @@
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.stuartsierra/component "0.4.0"]
-                 [nomnom/abracad "0.5.1"]]
+                 [nomnom/abracad "0.5.1"]
+
+                 ;; doc generator
+                 [cddr/integrity "0.3.0-SNAPSHOT"
+                  :exclusions [com.damballa/abracad org.clojure/clojure]]
+                 [metosin/ring-swagger "0.26.2"]]
   :deploy-repositories {"clojars" {:sign-releases false
                                    :username :env/clojars_username
                                    :password :env/clojars_password}}

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,10 @@
 
   :profiles {:dev
              {:resource-paths ["dev-resources"]
-              :dependencies [[org.clojure/tools.logging "0.5.0"]
+              :global-vars {*warn-on-reflection* true}
+              :dependencies [[org.clojure/tools.logging "1.1.0"]
+                             [ch.qos.logback/logback-classic "1.2.3"
+                  :exclusions [org.slf4j/slf4j-api]]
                              ;; test & dev deps
                              [clj-http "3.10.0"]
                              [ring-jetty-component "0.3.1"

--- a/script/ci-test
+++ b/script/ci-test
@@ -10,6 +10,7 @@ LEIN_FAST_TRAMPOLINE=1 lein trampoline cloverage \
                     --no-text \
                     --no-html \
                     --no-summary \
+                    --ns-exclude-regex ".*basic.*" \
                     -o $PWD
 testRes=$?
 mkdir -p coverage

--- a/src/duckula/avro/schema.clj
+++ b/src/duckula/avro/schema.clj
@@ -1,0 +1,58 @@
+(ns duckula.avro.schema
+  "Generates a prismatic schema from an avro one -
+  ported from https://github.com/cddr/integrity/blob/00326c259e5ff3ab94a37ec032da5a0d08932441/src/integrity/avro.clj
+  to support union types"
+  (:require
+    [schema.core :as s :refer [Bool Str Any]])
+  (:import
+    (org.apache.avro
+      Schema$Type)))
+
+
+(def ByteArray (Class/forName "[B"))
+
+
+(defn ->map [avro-schema]
+  (condp = (.getType avro-schema)
+
+    ;; Primitive types
+    Schema$Type/BOOLEAN Bool
+    Schema$Type/INT     Integer
+    Schema$Type/LONG    Long
+    Schema$Type/FLOAT   Float
+    Schema$Type/DOUBLE  Double
+    Schema$Type/BYTES   ByteArray
+    Schema$Type/STRING  Str
+
+    ;; Complex Types
+    Schema$Type/RECORD
+    (apply hash-map (mapcat (fn [key val]
+                              [(keyword key) val])
+                            (map #(.name %) (.getFields avro-schema))
+                            (map #(->map (.schema %)) (.getFields avro-schema))))
+
+    Schema$Type/ENUM
+    (apply s/enum (.getEnumSymbols avro-schema))
+
+    Schema$Type/ARRAY
+    [(->map (.getElementType avro-schema))]
+
+    Schema$Type/MAP
+    {Str (->map (.getValueType avro-schema))}
+
+    Schema$Type/FIXED
+    (s/pred (fn [str-val]
+              (<= (.getFixedSize avro-schema) (count str-val)))
+            'exceeds-fixed-size)
+
+    Schema$Type/NULL
+    Any
+    Schema$Type/UNION
+    (map ->map (.getTypes avro-schema))
+    ;; else
+    {:unknown avro-schema}))
+
+
+(defn avro-errors [schema value]
+  (let [schema-as-map (->map schema)]
+    (s/check schema-as-map value)))

--- a/src/duckula/avro/schema.clj
+++ b/src/duckula/avro/schema.clj
@@ -5,18 +5,18 @@
   (:require
     [schema.core :as s])
   (:import
+      (clojure.lang Keyword)
+
     (org.apache.avro
       Schema$Type)))
 
 
 (def ByteArray (Class/forName "[B"))
 
-(def kw (type :yoooo))
-
 (def any s/Any)
 
 (def string s/Str)
-(def any-map {kw any})
+(def any-map {Keyword any})
 
 
 (defn ->map [avro-schema]

--- a/src/duckula/avro/schema.clj
+++ b/src/duckula/avro/schema.clj
@@ -46,13 +46,8 @@
             'exceeds-fixed-size)
 
     Schema$Type/NULL
-    Any
+    s/Any
     Schema$Type/UNION
-    (map ->map (.getTypes avro-schema))
+    (apply s/either (map ->map (.getTypes avro-schema)))
     ;; else
     {:unknown avro-schema}))
-
-
-(defn avro-errors [schema value]
-  (let [schema-as-map (->map schema)]
-    (s/check schema-as-map value)))

--- a/src/duckula/avro/schema.clj
+++ b/src/duckula/avro/schema.clj
@@ -5,8 +5,8 @@
   (:require
     [schema.core :as s])
   (:import
-      (clojure.lang Keyword)
-
+    (clojure.lang
+      Keyword)
     (org.apache.avro
       Schema$Type)))
 

--- a/src/duckula/avro/schema.clj
+++ b/src/duckula/avro/schema.clj
@@ -1,9 +1,9 @@
 (ns duckula.avro.schema
-  "Generates a prismatic schema from an avro one -
+  "Generates a Prismatic Schema from an Avro schema object -
   ported from https://github.com/cddr/integrity/blob/00326c259e5ff3ab94a37ec032da5a0d08932441/src/integrity/avro.clj
-  to support union types"
+  to support union types and other features"
   (:require
-    [schema.core :as s :refer [Bool Str Any]])
+    [schema.core :as s])
   (:import
     (org.apache.avro
       Schema$Type)))
@@ -11,18 +11,25 @@
 
 (def ByteArray (Class/forName "[B"))
 
+(def kw (type :yoooo))
+
+(def any s/Any)
+
+(def string s/Str)
+(def any-map {kw any})
+
 
 (defn ->map [avro-schema]
   (condp = (.getType avro-schema)
 
     ;; Primitive types
-    Schema$Type/BOOLEAN Bool
+    Schema$Type/BOOLEAN s/Bool
     Schema$Type/INT     Integer
     Schema$Type/LONG    Long
     Schema$Type/FLOAT   Float
     Schema$Type/DOUBLE  Double
     Schema$Type/BYTES   ByteArray
-    Schema$Type/STRING  Str
+    Schema$Type/STRING  s/Str
 
     ;; Complex Types
     Schema$Type/RECORD
@@ -38,7 +45,7 @@
     [(->map (.getElementType avro-schema))]
 
     Schema$Type/MAP
-    {Str (->map (.getValueType avro-schema))}
+    {s/Str (->map (.getValueType avro-schema))}
 
     Schema$Type/FIXED
     (s/pred (fn [str-val]

--- a/src/duckula/component/basic_monitoring.clj
+++ b/src/duckula/component/basic_monitoring.clj
@@ -1,20 +1,24 @@
 (ns duckula.component.basic-monitoring
   (:refer-clojure :exclude [key])
-  (:require [duckula.protocol]
-            [clojure.tools.logging :as log]))
+  (:require
+    [clojure.tools.logging :as log]
+    [duckula.protocol]))
 
-(def BasicMonitoring
-  (reify duckula.protocol/Monitoring
-    (record-timing [this key time-ms]
-      (log/infof "request=%s time=%s" key time-ms))
-    (on-success [this key response]
-      (log/infof "request=%s status=success:%s" key (:status response)))
-    (on-error [this key]
-      (log/warnf "request=%s status=error" key))
-    (on-failure [this key]
-      (log/errorf "request=%s status=failure" key))
-    (on-not-found [this key uri]
-      (log/warnf "request=%s status=not-found uri=%s" key uri))
-    (track-exception [this exception] (log/error exception))
-    (track-exception [this exception data]
-      (log/errorf exception "data=%s" data))))
+
+(defrecord BasicMonitoring []
+  duckula.protocol/Monitoring
+  (record-timing [_this key time-ms]
+    (log/infof "request=%s time=%s" key time-ms))
+  (on-success [_this key response]
+    (log/infof "request=%s status=success:%s" key (:status response)))
+  (on-error [_this key]
+    (log/warnf "request=%s status=error" key))
+  (on-failure [_this key]
+    (log/errorf "request=%s status=failure" key))
+  (on-not-found [_this key uri]
+    (log/warnf "request=%s status=not-found uri=%s" key uri))
+  (track-exception [_this exception] (log/error exception))
+  (track-exception [_this exception data]
+    (log/errorf exception "data=%s" data)))
+
+(def basic (->BasicMonitoring))

--- a/src/duckula/component/basic_monitoring.clj
+++ b/src/duckula/component/basic_monitoring.clj
@@ -23,4 +23,5 @@
     [_this exception data]
     (log/errorf exception "data=%s" data)))
 
+
 (def basic (->BasicMonitoring))

--- a/src/duckula/component/basic_monitoring.clj
+++ b/src/duckula/component/basic_monitoring.clj
@@ -17,8 +17,10 @@
     (log/errorf "request=%s status=failure" key))
   (on-not-found [_this key uri]
     (log/warnf "request=%s status=not-found uri=%s" key uri))
-  (track-exception [_this exception] (log/error exception))
-  (track-exception [_this exception data]
+  (track-exception
+    [_this exception] (log/error exception))
+  (track-exception
+    [_this exception data]
     (log/errorf exception "data=%s" data)))
 
 (def basic (->BasicMonitoring))

--- a/src/duckula/middleware.clj
+++ b/src/duckula/middleware.clj
@@ -1,0 +1,25 @@
+(ns duckula.middleware
+  "Minimal middleware to allow JSON based request handling"
+  (:require
+    [duckula.component.basic-monitoring :as monitoring]
+    [ring.middleware.defaults :as ring-defaults]
+    [ring.middleware.json :as ring-json]))
+
+
+(defn wrap-handler
+  "Wraps the ring request handler (most likely one built by duckula.handler
+  and adds required JSON handling middlewares"
+  [handler-fn]
+  (-> handler-fn
+      (ring-json/wrap-json-body {:keywords? true})
+      (ring-defaults/wrap-defaults ring-defaults/api-defaults)))
+
+
+(defn with-monitoring
+  "Simple handler, which makes it easy to use Duckula without Components"
+  ([handler]
+   (fn [req]
+     (handler (update-in req [:component] merge {:monitoring monitoring/basic}))))
+  ([handler monitoring-impl]
+   (fn [req]
+     (handler (update-in req [:component] merge {:monitoring monitoring-impl})))))

--- a/src/duckula/protocol.clj
+++ b/src/duckula/protocol.clj
@@ -1,18 +1,34 @@
 (ns duckula.protocol
   (:refer-clojure :exclude [key]))
 
+
 (defprotocol Monitoring
-  (record-timing [this key time-ms] "Records the time taken to process the request")
-  (on-success [this key reponse] "Increments given key on success. Also passes the reponse map.")
-  (on-error [this key] "Increments a counter when an error happens e.g. invalid input/output or logic processing error. Validation errors will be counted using this method, but exceptions are not passed here.")
-  (on-failure [this key]
+
+  (record-timing
+    [this key time-ms]
+    "Records the time taken to process the request")
+
+  (on-success
+    [this key reponse]
+    "Increments given key on success. Also passes the reponse map.")
+
+  (on-error
+    [this key]
+    "Increments a counter when an error happens e.g. invalid input/output or logic processing error. Validation errors will be counted using this method, but exceptions are not passed here.")
+
+  (on-failure
+    [this key]
     "Increments a counter when a failure happens e.g. an unexpected exception during request processing. Should also submit the error to an exception tracker using +track-exception+")
-  (on-not-found [this key uri]
+
+  (on-not-found
+    [this key uri]
     "Increments a counter on an endpoint not found")
+
   (track-exception
     [this exception data]
     [this exception]
     "Tracks that an exception was thrown"))
+
 
 (defmacro with-timing
   "Tiny macro to record timing of a given form."

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -37,7 +37,7 @@
                    :error avro.schema/string
                    :metadata avro.schema/any-map}
                   {:name "Error"})]
-      {410 {:description "Message with invalid schema provided"
+      {410 {:description "Request data didn't conform to the request data schema"
             :schema error}
        500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
             :schema error}}))
@@ -75,11 +75,12 @@
                             {:name (make-schema-name (or response path))})]
       {path {:post {:summary path
                     :description path
-                    :parameters {:description (when request-avro-schema
-                                                (.getDoc request-avro-schema))
+                    :parameters {;:description (if request-avro-schema (.getDoc request-avro-schema) ":no-doc:")
                                  :body request-schema}
                     :responses (merge error-schemas
-                                      {200 {:description (when response-avro-schema (.getDoc response-avro-schema))
+                                      {200 {:description (if response-avro-schema
+                                                           (.getDoc response-avro-schema)
+                                                           ":no-doc:")
                                             :schema response-schema}})}}}))
 
 

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -1,11 +1,12 @@
 (ns duckula.swagger
   "Provides a Ring middleware which can serve swagger.json generated from the API config
-  as well as Swagger UI to view it"
+  as well as Swagger UI to view it.
+  Note that we're ignoring reflection warnings as they don't matter in dev mode, and in production
+  all schemas are (should be) parsed only once."
   (:require
     [cheshire.core :as json]
     [clojure.string :as string]
     [duckula.avro :as avro]
-    ;; These should optional
     [duckula.avro.schema :as avro.schema]
     [duckula.handler]
     [ring.swagger.swagger-ui :as swagger.ui]

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -79,8 +79,8 @@
    :definitions {}
    :paths (->> endpoints
                (map
-                (fn [[path config]] (endpoint->swagger (str prefix path)
-                                                       (assoc config :mangle-names? mangle-names))))
+                 (fn [[path config]] (endpoint->swagger (str prefix path)
+                                                        (assoc config :mangle-names? mangle-names))))
                (into {}))})
 
 

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -70,6 +70,7 @@
 
 
 (defn config->swagger
+
   [{:keys [name prefix endpoints mangle-names?] :as _config}]
   {:swagger "2.0"
    :info {:title (str "Swagger API: " name)
@@ -81,6 +82,7 @@
                (map
                  (fn [[path config]] (endpoint->swagger (str prefix path)
                                                         (assoc config :mangle-names? mangle-names))))
+               (sort-by (fn [[path _]] path))
                (into {}))})
 
 

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -1,7 +1,8 @@
 (ns duckula.swagger
   (:require
     [duckula.avro :as avro]
-    [duckula.avro.schema :as avro.schema]))
+    [duckula.avro.schema :as avro.schema]
+    [ring.swagger.swagger2 :as rs]))
 
 
 (defn endpoint->swagger [path config]
@@ -37,5 +38,11 @@
    :paths (->> config
                :endpoints
                (map
-                (fn [[path config]] (endpoint->swagger path config)))
+                 (fn [[path config]] (endpoint->swagger path config)))
                (into {}))})
+
+
+(defn generate [config]
+  (-> config
+      config->swagger
+      rs/swagger-json))

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -1,8 +1,16 @@
 (ns duckula.swagger
   (:require
+    [cheshire.core :as json]
+    [clojure.string :as string]
     [duckula.avro :as avro]
     [duckula.avro.schema :as avro.schema]
+    [duckula.handler]
+    [ring.swagger.swagger-ui :as swagger.ui]
     [ring.swagger.swagger2 :as rs]))
+
+
+(defn make-schema-name [req-schema-path]
+  (string/replace req-schema-path "/" "."))
 
 
 (defn endpoint->swagger [path config]
@@ -13,19 +21,23 @@
                       avro/load-schemas))
 
         req-schema (if req-sch
-                     (avro.schema/->map req-sch)
+                     (with-meta
+                       (avro.schema/->map req-sch)
+                       {:name (make-schema-name request)})
                      {})
         resp-sch (when response
                    (-> response
                        avro/name->path
                        avro/load-schemas))
         resp-schema (if resp-sch
-                      (avro.schema/->map resp-sch)
+                      (with-meta
+                        (avro.schema/->map resp-sch)
+                        {:name (make-schema-name response)})
                       {})]
     {path {:post {:summary path
                   :description path
                   :parameters {:body req-schema}
-                  :response {200 {:schema resp-schema}}}}}))
+                  :responses {200 {:schema resp-schema}}}}}))
 
 
 (defn config->swagger [config]
@@ -46,3 +58,31 @@
   (-> config
       config->swagger
       rs/swagger-json))
+
+
+(defn build-handler
+  "Returns a Ring handler which returns auto-generated
+  swagger json, based on the Duckula config"
+  [config]
+  (let [swagger-json (generate config)]
+    (fn swagger-json-handler [_req]
+      {:status 200
+       :body (json/generate-string swagger-json)
+       :headers {"content-type" "application/json"}})))
+
+
+(def swagger-ui-handler swagger.ui/swagger-ui)
+
+
+(defn with-docs [api-config]
+  (let [ui-handler (swagger-ui-handler {:path "/~docs/ui"
+                                        :swagger-docs "/~docs/swagger.json"})
+        swagger-json-handler (build-handler api-config)
+        api-handler (duckula.handler/build api-config)]
+
+    (fn [{:keys [uri] :as req}]
+      (println uri)
+        (cond
+          (string/starts-with? uri "/~docs/ui") (ui-handler req)
+          (= uri "/~docs/swagger.json") (swagger-json-handler req)
+          :else (api-handler req)))))

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -84,7 +84,7 @@
                                             :schema response-schema}})}}}))
 
 
-  (defn config->swagger [{:keys [name endpoints] :as _config}]
+  (defn config->swagger [{:keys [name prefix endpoints] :as _config}]
     {:swagger "2.0"
      :info {:title (str "Swagger API: " name)
             :version "0.0.1"}
@@ -93,7 +93,7 @@
      :definitions {}
      :paths (->> endpoints
                  (map
-                   (fn [[path config]] (endpoint->swagger path config)))
+                   (fn [[path config]] (endpoint->swagger (str prefix path) config)))
                  (into {}))})
 
 

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -32,10 +32,10 @@
 
 (when dependencies-satisfied?
   (def error-schemas
-    (let [error avro.schema/string #_ (with-meta
+    (let [error (with-meta
                   {:message avro.schema/string
                    :error avro.schema/string
-                   :metadata avro.schema/string #_  avro.schema/any-map}
+                   :metadata avro.schema/any-map}
                   {:name "Error"})]
       {410 {:description "Message with invalid schema provided"
             :schema error}

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -1,0 +1,41 @@
+(ns duckula.swagger
+  (:require
+    [duckula.avro :as avro]
+    [duckula.avro.schema :as avro.schema]))
+
+
+(defn endpoint->swagger [path config]
+  (let [{:keys [request response]} config
+        req-sch (when request
+                  (-> request
+                      avro/name->path
+                      avro/load-schemas))
+
+        req-schema (if req-sch
+                     (avro.schema/->map req-sch)
+                     {})
+        resp-sch (when response
+                   (-> response
+                       avro/name->path
+                       avro/load-schemas))
+        resp-schema (if resp-sch
+                      (avro.schema/->map resp-sch)
+                      {})]
+    {path {:post {:summary path
+                  :description path
+                  :parameters {:body req-schema}
+                  :response {200 {:schema resp-schema}}}}}))
+
+
+(defn config->swagger [config]
+  {:swagger "2.0"
+   :info {:title "Swagger API"
+          :version "0.0.1"}
+   :produces ["application/json"]
+   :consumes ["application/json"]
+   :definitions {}
+   :paths (->> config
+               :endpoints
+               (map
+                (fn [[path config]] (endpoint->swagger path config)))
+               (into {}))})

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -1,88 +1,133 @@
 (ns duckula.swagger
+  "Provides a Ring middleware which can serve swagger.json generated from the API config
+  as well as Swagger UI to view it"
   (:require
     [cheshire.core :as json]
     [clojure.string :as string]
     [duckula.avro :as avro]
-    [duckula.avro.schema :as avro.schema]
-    [duckula.handler]
-    [ring.swagger.swagger-ui :as swagger.ui]
-    [ring.swagger.swagger2 :as rs]))
+    [duckula.handler]))
 
 
-(defn make-schema-name [req-schema-path]
-  (string/replace req-schema-path "/" "."))
+(try
+
+  (require '[duckula.avro.schema :as avro.schema]
+           '[ring.swagger.swagger-ui :as swagger.ui]
+           '[ring.swagger.swagger2 :as rs])
+  (catch Exception _err))
 
 
-(defn endpoint->swagger [path config]
-  (let [{:keys [request response]} config
-        req-sch (when request
-                  (-> request
-                      avro/name->path
-                      avro/load-schemas))
-
-        req-schema (if req-sch
-                     (with-meta
-                       (avro.schema/->map req-sch)
-                       {:name (make-schema-name request)})
-                     {})
-        resp-sch (when response
-                   (-> response
-                       avro/name->path
-                       avro/load-schemas))
-        resp-schema (if resp-sch
-                      (with-meta
-                        (avro.schema/->map resp-sch)
-                        {:name (make-schema-name response)})
-                      {})]
-    {path {:post {:summary path
-                  :description path
-                  :parameters {:body req-schema}
-                  :responses {200 {:schema resp-schema}}}}}))
+(def dependencies-satisfied?
+  (every?
+    true?
+    [(if (find-ns 'ring.swagger.swagger2)
+       true
+       (println "ring.swagger not found"))
+     (if (find-ns 'ring.swagger.swagger-ui)
+       true
+       (println "ring.swagger.swagger-ui not found"))
+     (if (find-ns 'schema.core)
+       true
+       (println "Plumatic Schema not found"))]))
 
 
-(defn config->swagger [config]
-  {:swagger "2.0"
-   :info {:title "Swagger API"
-          :version "0.0.1"}
-   :produces ["application/json"]
-   :consumes ["application/json"]
-   :definitions {}
-   :paths (->> config
-               :endpoints
-               (map
-                 (fn [[path config]] (endpoint->swagger path config)))
-               (into {}))})
+(when dependencies-satisfied?
+  (def error-schemas
+    (let [error avro.schema/string #_ (with-meta
+                  {:message avro.schema/string
+                   :error avro.schema/string
+                   :metadata avro.schema/string #_  avro.schema/any-map}
+                  {:name "Error"})]
+      {410 {:description "Message with invalid schema provided"
+            :schema error}
+       500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+            :schema error}}))
 
 
-(defn generate [config]
-  (-> config
-      config->swagger
-      rs/swagger-json))
+  (defn make-schema-name [req-schema-path]
+    (string/replace req-schema-path "/" "."))
 
 
-(defn build-handler
-  "Returns a Ring handler which returns auto-generated
+  (defn make-definition [response path]
+              (let [response-avro-schema (when response
+                                 (-> response avro/name->path avro/load-schemas))
+          response-schema (with-meta
+                            (if response-avro-schema
+                              (avro.schema/->map response-avro-schema)
+                             avro.schema/any)
+                            {:name (make-schema-name (or response path))})]
+  response-schema))
+
+  (defn endpoint->swagger [path config]
+    (let [{:keys [request response]} config
+          request-avro-schema (when request
+                                (-> request avro/name->path avro/load-schemas))
+          request-schema (with-meta
+                           (if request-avro-schema
+                             (avro.schema/->map request-avro-schema)
+                             avro.schema/any)
+                           {:name (make-schema-name (or request path))})
+          response-avro-schema (when response
+                                 (-> response avro/name->path avro/load-schemas))
+          response-schema (with-meta
+                            (if response-avro-schema
+                              (avro.schema/->map response-avro-schema)
+                             avro.schema/any)
+                            {:name (make-schema-name (or response path))})]
+      {path {:post {:summary path
+                    :description path
+                    :parameters {:description (when request-avro-schema
+                                                (.getDoc request-avro-schema))
+                                 :body request-schema}
+                    :responses (merge error-schemas
+                                      {200 {:description (when response-avro-schema (.getDoc response-avro-schema))
+                                            :schema response-schema}})}}}))
+
+
+  (defn config->swagger [{:keys [name endpoints] :as _config}]
+    {:swagger "2.0"
+     :info {:title (str "Swagger API: " name)
+            :version "0.0.1"}
+     :produces ["application/json"]
+     :consumes ["application/json"]
+     :definitions {}
+     :paths (->> endpoints
+                 (map
+                   (fn [[path config]] (endpoint->swagger path config)))
+                 (into {}))})
+
+
+  (defn generate [config]
+    (-> config
+        config->swagger
+        rs/swagger-json))
+
+
+  (defn build-handler
+    "Returns a Ring handler which returns auto-generated
   swagger json, based on the Duckula config"
-  [config]
-  (let [swagger-json (generate config)]
-    (fn swagger-json-handler [_req]
-      {:status 200
-       :body (json/generate-string swagger-json)
-       :headers {"content-type" "application/json"}})))
+    [config]
+    (let [swagger-json (generate config)]
+      (fn swagger-json-handler [_req]
+        {:status 200
+         :body (json/generate-string swagger-json)
+         :headers {"content-type" "application/json"}})))
 
 
-(def swagger-ui-handler swagger.ui/swagger-ui)
+  (def swagger-ui-handler swagger.ui/swagger-ui)
 
 
-(defn with-docs [api-config]
-  (let [ui-handler (swagger-ui-handler {:path "/~docs/ui"
-                                        :swagger-docs "/~docs/swagger.json"})
-        swagger-json-handler (build-handler api-config)
-        api-handler (duckula.handler/build api-config)]
+  (def ui-prefix "/~docs/ui")
+  (def swagger-json-path "/~docs/swagger.json")
 
-    (fn [{:keys [uri] :as req}]
-      (println uri)
+
+  (defn with-docs [api-config]
+    (let [ui-handler (swagger-ui-handler {:path ui-prefix
+                                          :swagger-docs swagger-json-path})
+          swagger-json-handler (build-handler api-config)
+          api-handler (duckula.handler/build api-config)]
+
+      (fn [{:keys [uri] :as req}]
         (cond
-          (string/starts-with? uri "/~docs/ui") (ui-handler req)
-          (= uri "/~docs/swagger.json") (swagger-json-handler req)
-          :else (api-handler req)))))
+          (string/starts-with? uri ui-prefix) (ui-handler req)
+          (= uri swagger-json-path) (swagger-json-handler req)
+          :else (api-handler req))))))

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -36,7 +36,7 @@
 
 
 (defn make-definition
-  [{:keys [avro-schema path]}]
+  [{:keys [avro-schema path mangle-names?]}]
   (let [avro-schema (when avro-schema
                       (avro/load-schemas (avro/name->path avro-schema)))
         schema (with-meta
@@ -52,11 +52,13 @@
 
 (defn endpoint->swagger
   [path config]
-  (let [{:keys [request response]} config
+  (let [{:keys [request response mangle-names?]} config
         request-config (make-definition {:avro-schema request
+                                         :mangle-names? mangle-names?
                                          :type ::request
                                          :path path})
         response-config (make-definition {:avro-schema response
+                                          :mangle-names? mangle-names?
                                           :type ::response
                                           :path path})]
     {path {:post {:summary path
@@ -68,7 +70,7 @@
 
 
 (defn config->swagger
-  [{:keys [name prefix endpoints] :as _config}]
+  [{:keys [name prefix endpoints mangle-names?] :as _config}]
   {:swagger "2.0"
    :info {:title (str "Swagger API: " name)
           :version "0.0.1"}
@@ -77,7 +79,8 @@
    :definitions {}
    :paths (->> endpoints
                (map
-                 (fn [[path config]] (endpoint->swagger (str prefix path) config)))
+                (fn [[path config]] (endpoint->swagger (str prefix path)
+                                                       (assoc config :mangle-names? mangle-names))))
                (into {}))})
 
 

--- a/src/duckula/swagger.clj
+++ b/src/duckula/swagger.clj
@@ -5,130 +5,103 @@
     [cheshire.core :as json]
     [clojure.string :as string]
     [duckula.avro :as avro]
-    [duckula.handler]))
+    [duckula.handler]
+
+    ;; These should optional
+    [duckula.avro.schema :as avro.schema]
+    [ring.swagger.swagger-ui :as swagger.ui]
+    [ring.swagger.swagger2 :as rs]))
 
 
-(try
 
-  (require '[duckula.avro.schema :as avro.schema]
-           '[ring.swagger.swagger-ui :as swagger.ui]
-           '[ring.swagger.swagger2 :as rs])
-  (catch Exception _err))
+(def error-schemas
+  (let [error (with-meta
+                {:message avro.schema/string
+                 :error avro.schema/string
+                 :metadata avro.schema/any-map}
+                {:name "Error"})]
+    {410 {:description "Request data didn't conform to the request data schema"
+          :schema error}
+     500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+          :schema error}}))
 
-
-(def dependencies-satisfied?
-  (every?
-    true?
-    [(if (find-ns 'ring.swagger.swagger2)
-       true
-       (println "ring.swagger not found"))
-     (if (find-ns 'ring.swagger.swagger-ui)
-       true
-       (println "ring.swagger.swagger-ui not found"))
-     (if (find-ns 'schema.core)
-       true
-       (println "Plumatic Schema not found"))]))
+(defn make-schema-name [req-schema-path]
+  (string/replace req-schema-path "/" "."))
 
 
-(when dependencies-satisfied?
-  (def error-schemas
-    (let [error (with-meta
-                  {:message avro.schema/string
-                   :error avro.schema/string
-                   :metadata avro.schema/any-map}
-                  {:name "Error"})]
-      {410 {:description "Request data didn't conform to the request data schema"
-            :schema error}
-       500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
-            :schema error}}))
+(defn make-definition [{:keys [type avro-schema-path path]}]
+  (let [avro-schema (when avro-schema-path
+                      (-> avro-schema-path avro/name->path avro/load-schemas))
+        schema (with-meta
+                 (if avro-schema
+                   (avro.schema/->map avro-schema)
+                   avro.schema/any)
+                 {:name (make-schema-name (or avro-schema-path path))})
+        description (if avro-schema
+                      (.getDoc avro-schema)
+                      ":no-doc:")]
+    {:schema schema :description description}))
 
 
-  (defn make-schema-name [req-schema-path]
-    (string/replace req-schema-path "/" "."))
+(defn endpoint->swagger [path config]
+  (let [{:keys [request response]} config
+        request-config (make-definition {:avro-schema-path request
+                                         :path path})
+        response-config (make-definition {:avro-schema-path response
+                                          :path path})]
+    {path {:post {:summary path
+                  :description (or (:description request-config) "")
+                  :parameters {:body (:schema request-config)}
+                  :responses (merge error-schemas
+                                    {200 {:description (:description response-config)
+                                          :schema (:schema response-config)}})}}}))
 
 
-  (defn make-definition [response path]
-              (let [response-avro-schema (when response
-                                 (-> response avro/name->path avro/load-schemas))
-          response-schema (with-meta
-                            (if response-avro-schema
-                              (avro.schema/->map response-avro-schema)
-                             avro.schema/any)
-                            {:name (make-schema-name (or response path))})]
-  response-schema))
-
-  (defn endpoint->swagger [path config]
-    (let [{:keys [request response]} config
-          request-avro-schema (when request
-                                (-> request avro/name->path avro/load-schemas))
-          request-schema (with-meta
-                           (if request-avro-schema
-                             (avro.schema/->map request-avro-schema)
-                             avro.schema/any)
-                           {:name (make-schema-name (or request path))})
-          response-avro-schema (when response
-                                 (-> response avro/name->path avro/load-schemas))
-          response-schema (with-meta
-                            (if response-avro-schema
-                              (avro.schema/->map response-avro-schema)
-                             avro.schema/any)
-                            {:name (make-schema-name (or response path))})]
-      {path {:post {:summary path
-                    :description path
-                    :parameters {;:description (if request-avro-schema (.getDoc request-avro-schema) ":no-doc:")
-                                 :body request-schema}
-                    :responses (merge error-schemas
-                                      {200 {:description (if response-avro-schema
-                                                           (.getDoc response-avro-schema)
-                                                           ":no-doc:")
-                                            :schema response-schema}})}}}))
+(defn config->swagger [{:keys [name prefix endpoints] :as _config}]
+  {:swagger "2.0"
+   :info {:title (str "Swagger API: " name)
+          :version "0.0.1"}
+   :produces ["application/json"]
+   :consumes ["application/json"]
+   :definitions {}
+   :paths (->> endpoints
+               (map
+                (fn [[path config]] (endpoint->swagger (str prefix path) config)))
+               (into {}))})
 
 
-  (defn config->swagger [{:keys [name prefix endpoints] :as _config}]
-    {:swagger "2.0"
-     :info {:title (str "Swagger API: " name)
-            :version "0.0.1"}
-     :produces ["application/json"]
-     :consumes ["application/json"]
-     :definitions {}
-     :paths (->> endpoints
-                 (map
-                   (fn [[path config]] (endpoint->swagger (str prefix path) config)))
-                 (into {}))})
+(defn generate [config]
+  (-> config
+      config->swagger
+      rs/swagger-json))
 
 
-  (defn generate [config]
-    (-> config
-        config->swagger
-        rs/swagger-json))
-
-
-  (defn build-handler
-    "Returns a Ring handler which returns auto-generated
+(defn build-handler
+  "Returns a Ring handler which returns auto-generated
   swagger json, based on the Duckula config"
-    [config]
-    (let [swagger-json (generate config)]
-      (fn swagger-json-handler [_req]
-        {:status 200
-         :body (json/generate-string swagger-json)
-         :headers {"content-type" "application/json"}})))
+  [config]
+  (let [swagger-json (generate config)]
+    (fn swagger-json-handler [_req]
+      {:status 200
+       :body (json/generate-string swagger-json)
+       :headers {"content-type" "application/json"}})))
 
 
-  (def swagger-ui-handler swagger.ui/swagger-ui)
+(def swagger-ui-handler swagger.ui/swagger-ui)
 
 
-  (def ui-prefix "/~docs/ui")
-  (def swagger-json-path "/~docs/swagger.json")
+(def ui-prefix "/~docs/ui")
+(def swagger-json-path "/~docs/swagger.json")
 
 
-  (defn with-docs [api-config]
-    (let [ui-handler (swagger-ui-handler {:path ui-prefix
-                                          :swagger-docs swagger-json-path})
-          swagger-json-handler (build-handler api-config)
-          api-handler (duckula.handler/build api-config)]
+(defn with-docs [api-config]
+  (let [ui-handler (swagger-ui-handler {:path ui-prefix
+                                        :swagger-docs swagger-json-path})
+        swagger-json-handler (build-handler api-config)
+        api-handler (duckula.handler/build api-config)]
 
-      (fn [{:keys [uri] :as req}]
-        (cond
-          (string/starts-with? uri ui-prefix) (ui-handler req)
-          (= uri swagger-json-path) (swagger-json-handler req)
-          :else (api-handler req))))))
+    (fn [{:keys [uri] :as req}]
+      (cond
+        (string/starts-with? uri ui-prefix) (ui-handler req)
+        (= uri swagger-json-path) (swagger-json-handler req)
+        :else (api-handler req)))))

--- a/test/duckula/avro/schema_test.clj
+++ b/test/duckula/avro/schema_test.clj
@@ -1,5 +1,7 @@
 (ns duckula.avro.schema-test
   (:require
+    [abracad.avro.codec :as avro.codec]
+    [cheshire.core :as json]
     [clojure.test :refer [is deftest testing]]
     [duckula.avro]
     [duckula.avro.schema :as avro.schema]
@@ -17,5 +19,17 @@
                  :message "foo"}]
     (is (= payload
            (schema.core/validate
-            (avro.schema/->map sample-avro-schema)
-            payload)))))
+             (avro.schema/->map sample-avro-schema)
+             payload)))))
+
+
+(deftest converts-avro-to-primastic-schema
+  (let [avro-schema (avro.codec/parse-schema*
+                      (json/generate-string
+                        {:name "Foo"
+                         :doc "a foo!"
+                         :type "record"
+                         :fields [{:name "bar" :type "string" :doc "bah"}]}))
+        expected-schema {:bar avro.schema/string}]
+    (is (= expected-schema
+           (avro.schema/->map avro-schema)))))

--- a/test/duckula/avro/schema_test.clj
+++ b/test/duckula/avro/schema_test.clj
@@ -1,0 +1,21 @@
+(ns duckula.avro.schema-test
+  (:require
+    [clojure.test :refer [is deftest testing]]
+    [duckula.avro]
+    [duckula.avro.schema :as avro.schema]
+    [schema.core]))
+
+
+(def sample-avro-schema
+  (duckula.avro/load-schemas "schema/endpoint/search/test/Response.avsc"))
+
+
+(deftest generates-a-prismatic-schema-from-avro
+  (let [payload {:status "error"
+                 :items [{:content "foo" :id 1}
+                         {:content "bar" :id 2}]
+                 :message "foo"}]
+    (is (= payload
+           (schema.core/validate
+            (avro.schema/->map sample-avro-schema)
+            payload)))))

--- a/test/duckula/avro_test.clj
+++ b/test/duckula/avro_test.clj
@@ -10,17 +10,17 @@
            (duckula.avro/validate-with-schema nil :foo))))
   (testing "loads schema and creates a validator"
     (let [validator (duckula.avro/make-validator
-                     "schema/endpoint/search/test/Response.avsc"
-                     {:mangle-names? false
-                      :soft-validate? false})]
+                      "schema/endpoint/search/test/Response.avsc"
+                      {:mangle-names? false
+                       :soft-validate? false})]
       (is (fn? validator))
       (is (= {:schema-name "schema/endpoint/search/test/Response.avsc"
               :soft-validate? false}
              (meta validator)))))
   (testing "validate-with-underscore"
     (let [validator (duckula.avro/make-validator
-                     "schema/endpoint/search/test/Request.avsc"
-                     {:mangle-names? false})]
+                      "schema/endpoint/search/test/Request.avsc"
+                      {:mangle-names? false})]
       (is (= {:order_by "created_at"
               :query    "test"}
              (validator {:query "test" :order_by "created_at"})))
@@ -30,8 +30,8 @@
     ;; test that outside the make-validator fn
     ;; clojure structure will be converted to use dashes for schema validation
     (let [validator (duckula.avro/make-validator
-                     "schema/endpoint/search/test/Request.avsc"
-                     {:mangle-names? true})]
+                      "schema/endpoint/search/test/Request.avsc"
+                      {:mangle-names? true})]
       (is (thrown? Exception
             (validator {:query "test" :order_by "created_at"})))
       (is (= {:order-by "created-at"
@@ -40,12 +40,24 @@
 
 
 (deftest composable-schemas
-  (let [validator (duckula.avro/make-validator
-                    ["schema/endpoint/search/get/TagItem.avsc"
-                     "schema/endpoint/search/get/Response.avsc"] {:mangle-names? false})]
-    (is (fn? validator))
-    (let [payload {:id "foo"
-                   :results [{:name "test" :priority 0}
-                             {:name "foo" :priority 10}]}]
-      (is (= payload
-             (validator payload))))))
+  (testing "from resources"
+    (let [validator (duckula.avro/make-validator
+                      ["schema/endpoint/search/get/TagItem.avsc"
+                       "schema/endpoint/search/get/Response.avsc"] {:mangle-names? false})]
+      (is (fn? validator))
+      (let [payload {:id "foo"
+                     :results [{:name "test" :priority 0}
+                               {:name "foo" :priority 10}]}]
+        (is (= payload
+               (validator payload))))))
+  (testing "inline schemas"
+    (let [validator (duckula.avro/make-validator
+                      {:name "TagItem"
+                       :type "record"
+                       :fields [{:name "name" :type "string"}
+                                {:name "priority" :type "long"}]}
+                      {:mangle-names? false})]
+      (is (fn? validator))
+      (let [payload {:name "banans" :priority 100}]
+        (is (= payload
+               (validator payload)))))))

--- a/test/duckula/avro_test.clj
+++ b/test/duckula/avro_test.clj
@@ -14,7 +14,7 @@
                       {:mangle-names? false
                        :soft-validate? false})]
       (is (fn? validator))
-      (is (= {:schema-name "schema/endpoint/search/test/Response.avsc"
+      (is (= {:schema-name "search.test.Response"
               :soft-validate? false}
              (meta validator)))))
   (testing "validate-with-underscore"

--- a/test/duckula/avro_test.clj
+++ b/test/duckula/avro_test.clj
@@ -1,37 +1,48 @@
 (ns duckula.avro-test
-  (:require [clojure.test :refer :all]
-            [duckula.avro]))
+  (:require
+    [clojure.test :refer [deftest testing is]]
+    [duckula.avro]))
+
 
 (deftest validation
   (testing "it skips validation if no schema"
     (is (= :foo
            (duckula.avro/validate-with-schema nil :foo))))
   (testing "loads schema and creates a validator"
-    (let [validator (duckula.avro/make-validator "schema/endpoint/search/test/Response.avsc" {:mangle-names? false :soft-validate? false})]
+    (let [validator (duckula.avro/make-validator
+                     "schema/endpoint/search/test/Response.avsc"
+                     {:mangle-names? false
+                      :soft-validate? false})]
       (is (fn? validator))
-      (is (= {:schema-name "schema/endpoint/search/test/Response.avsc" :soft-validate? false}
+      (is (= {:schema-name "schema/endpoint/search/test/Response.avsc"
+              :soft-validate? false}
              (meta validator)))))
   (testing "validate-with-underscore"
-    (let [validator (duckula.avro/make-validator "schema/endpoint/search/test/Request.avsc" {:mangle-names? false})]
+    (let [validator (duckula.avro/make-validator
+                     "schema/endpoint/search/test/Request.avsc"
+                     {:mangle-names? false})]
       (is (= {:order_by "created_at"
               :query    "test"}
              (validator {:query "test" :order_by "created_at"})))
       (is (thrown? Exception
-                   (validator {:query "test" :order-by "created_at"})))))
+            (validator {:query "test" :order-by "created_at"})))))
   (testing "validate-with-dashes"
     ;; test that outside the make-validator fn
     ;; clojure structure will be converted to use dashes for schema validation
-    (let [validator (duckula.avro/make-validator "schema/endpoint/search/test/Request.avsc" {:mangle-names? true})]
+    (let [validator (duckula.avro/make-validator
+                     "schema/endpoint/search/test/Request.avsc"
+                     {:mangle-names? true})]
       (is (thrown? Exception
-                   (validator {:query "test" :order_by "created_at"})))
+            (validator {:query "test" :order_by "created_at"})))
       (is (= {:order-by "created-at"
               :query    "test"}
              (validator {:query "test" :order-by "created-at"}))))))
 
+
 (deftest composable-schemas
   (let [validator (duckula.avro/make-validator
-                   ["schema/endpoint/search/get/TagItem.avsc"
-                    "schema/endpoint/search/get/Response.avsc"] {:mangle-names? false})]
+                    ["schema/endpoint/search/get/TagItem.avsc"
+                     "schema/endpoint/search/get/Response.avsc"] {:mangle-names? false})]
     (is (fn? validator))
     (let [payload {:id "foo"
                    :results [{:name "test" :priority 0}

--- a/test/duckula/compojure_test.clj
+++ b/test/duckula/compojure_test.clj
@@ -1,24 +1,29 @@
 (ns duckula.compojure-test
   "Verifies mounting a duckula handler under a Compojure namespace/prefix"
-  (:require [duckula.test.server :as test.server]
-            [duckula.handler]
-            [compojure.core :as compojure]
-            [clj-http.client :as http.client]
-            [cheshire.core :as json]
-            [clojure.test :refer :all]))
+  (:require
+    [cheshire.core :as json]
+    [clj-http.client :as http.client]
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [compojure.core :as compojure]
+    [duckula.avro]
+    [duckula.handler]
+    [duckula.test.server :as test.server]))
+
 
 (compojure/defroutes app
-  (compojure/GET "/some/endpoint" [] "foo")
-  (compojure/context "/rpc-api" []
-    (duckula.handler/build (assoc test.server/config
-                                  :prefix "/rpc-api"))))
+                     (compojure/GET "/some/endpoint" [] "foo")
+                     (compojure/context "/rpc-api" []
+                                        (duckula.handler/build (assoc test.server/config
+                                                                      :prefix "/rpc-api"))))
+
 
 (use-fixtures :once (fn [t]
                       (test.server/start-with-handler! app)
                       (t)
                       (test.server/stop!)))
 
-(deftest it-exposes-validated-api-as-part-of-compojre-router
+
+(deftest it-exposes-validated-api-as-part-of-compojure-router
   (testing "regular route"
     (let [response (http.client/get "http://localhost:3003/some/endpoint")]
       (is (= 200

--- a/test/duckula/compojure_test.clj
+++ b/test/duckula/compojure_test.clj
@@ -12,11 +12,11 @@
 
 
 (compojure/defroutes app
-                     (compojure/GET "/some/endpoint" [] "foo")
-                     (compojure/context "/rpc-api" []
-                                        (duckula.middleware/wrap-handler
-                                          (duckula.handler/build (assoc test.server/config
-                                                                        :prefix "/rpc-api")))))
+  (compojure/GET "/some/endpoint" [] "foo")
+  (compojure/context "/rpc-api" []
+                     (duckula.middleware/wrap-handler
+                       (duckula.handler/build (assoc test.server/config
+                                                     :prefix "/rpc-api")))))
 
 
 (use-fixtures :once (fn [t]

--- a/test/duckula/compojure_test.clj
+++ b/test/duckula/compojure_test.clj
@@ -7,14 +7,16 @@
     [compojure.core :as compojure]
     [duckula.avro]
     [duckula.handler]
+    [duckula.middleware]
     [duckula.test.server :as test.server]))
 
 
 (compojure/defroutes app
                      (compojure/GET "/some/endpoint" [] "foo")
                      (compojure/context "/rpc-api" []
-                                        (duckula.handler/build (assoc test.server/config
-                                                                      :prefix "/rpc-api"))))
+                                        (duckula.middleware/wrap-handler
+                                          (duckula.handler/build (assoc test.server/config
+                                                                        :prefix "/rpc-api")))))
 
 
 (use-fixtures :once (fn [t]

--- a/test/duckula/end_to_end_test.clj
+++ b/test/duckula/end_to_end_test.clj
@@ -85,4 +85,10 @@
       (is (= 404
              (:status response)))
       (is (= {:message "not found"}
-             (body response))))))
+             (body response)))))
+
+  (testing "swagger docs"
+    (testing "returns swagger.json"
+      (is (= 200 (:status (http.client/get "http://localhost:3003/~docs/swagger.json")))))
+    (testing "serves the Swagger UI"
+      (is (= 200 (:status (http.client/get "http://localhost:3003/~docs/ui")))))))

--- a/test/duckula/end_to_end_test.clj
+++ b/test/duckula/end_to_end_test.clj
@@ -1,18 +1,27 @@
 (ns duckula.end-to-end-test
-  (:require [duckula.test.server :as test.server]
-            [clj-http.client :as http.client]
-            [cheshire.core :as json]
-            [clojure.test :refer :all]))
+  (:require
+    [cheshire.core :as json]
+    [clj-http.client :as http.client]
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [duckula.avro]
+    [duckula.test.server :as test.server]))
+
 
 (use-fixtures :once (fn [t]
                       (test.server/start!)
                       (t)
                       (test.server/stop!)))
 
-(defn body [r]
-  (-> r
-      :body
-      (json/parse-string true)))
+
+(defn body
+  [r]
+  (try
+    (-> r
+        :body
+        (json/parse-string true))
+    (catch Exception _e
+      (:body r))))
+
 
 (deftest it-validates-ins-and-outs
   (testing "invalid input"
@@ -24,7 +33,7 @@
              (:status response)))
       (is (= {:message "Request failed"
               :error "Cannot write datum as schema"
-              :metadata {:schema-name "schema/endpoint/search/test/Request.avsc"
+              :metadata {:schema-name "search.test.Request"
                          :soft-validate? nil
                          :validation-type "duckula.handler/request"}}
              (body response)))))
@@ -37,7 +46,7 @@
       (is (= 500
              (:status response)))
       (is (= {:message "Request failed"
-              :metadata {:schema-name "schema/endpoint/number/multiply/Response.avsc"
+              :metadata {:schema-name "number.multiply.Response"
                          :soft-validate? nil
                          :validation-type "duckula.handler/response"}}
              (dissoc (body response) :error)))

--- a/test/duckula/handler_test.clj
+++ b/test/duckula/handler_test.clj
@@ -1,7 +1,9 @@
 (ns duckula.handler-test
-  (:require [clojure.test :refer :all]
-            [duckula.protocol]
-            [duckula.handler :as handler]))
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [duckula.handler :as handler]
+    [duckula.protocol]))
+
 
 (deftest metric-keys
   (testing "regular case"
@@ -30,59 +32,76 @@
                                        :endpoints {"/one/two/three" {:handler (fn [])}
                                                    "/bar/baz/ok-how-about-this" {:handler (fn [])}}})))))
 
+
 (deftest route-map-builder
   (let [search-handler (fn [])
         echo-handler (fn [])
         route-map (handler/build-route-map
-                   {:name "test-server-rpc"
-                    :prefix "test-pref"
-                    :endpoints {"/search/test" {:request "search/test/Request"
-                                                :response "search/test/Response"
-                                                :handler search-handler}
-                                "/echo" {:handler echo-handler}}})]
+                    {:name "test-server-rpc"
+                     :prefix "test-pref"
+                     :endpoints {"/search/test" {:request "search/test/Request"
+                                                 :response "search/test/Response"
+                                                 :handler search-handler}
+                                 "/echo" {:handler echo-handler}}})]
     (is (= echo-handler (get-in route-map ["test-pref/echo" :handler])))
     (is (fn? (get-in route-map ["test-pref/search/test" :request])))))
 
+
 (deftest composite-schema-builder
-  (let [search-handler (fn [])
-        static-response {:id "foo"
+  (let [static-response {:id "foo"
                          :results [{:name "test" :priority 0}
                                    {:name "foo" :priority 10}]}
         route-map (handler/build-route-map
-                   {:name "test-server-rpc"
-                    :prefix "test-pref"
-                    :endpoints {"/search/get" {:response ["search/get/TagItem"
-                                                          "search/get/Response"]
-                                               :handler (fn [& _args]
-                                                          static-response)}}})
+                    {:name "test-server-rpc"
+                     :prefix "test-pref"
+                     :endpoints {"/search/get" {:response ["search/get/TagItem"
+                                                           "search/get/Response"]
+                                                :handler (fn [& _args]
+                                                           static-response)}}})
         validator (get-in route-map ["test-pref/search/get" :response])]
     (is (fn? validator))
     (is (= static-response
            (validator static-response)))))
 
-(defn create-monitoring [metric-store]
+
+(defn create-monitoring
+  [metric-store]
   (reify
     duckula.protocol/Monitoring
-    (on-success [this key _response]
+    (on-success
+      [this key _response]
       (swap! metric-store (fn [store]
                             (update store key (fn [value]
                                                 (inc (or value 0)))))))
-    (on-error [this key]
+
+    (on-error
+      [this key]
       (swap! metric-store (fn [store] (assoc store key 1))))
-    (on-failure [this key]
+
+    (on-failure
+      [this key]
       (swap! metric-store (fn [store] (assoc store key 1))))
-    (record-timing [this key val]
+
+    (record-timing
+      [this key val]
       (swap! metric-store (fn [store]
                             (assoc store (str key ".timing") val))))
-    (track-exception [this err]
+
+    (track-exception
+      [this err]
       (swap! metric-store (fn [store]
                             (update store :exceptions conj err))))
-    (track-exception [this err data]
+
+    (track-exception
+      [this err data]
       (swap! metric-store (fn [store]
                             (update store :exceptions conj {:err err :data data}))))
-    (on-not-found [this key uri]
+
+    (on-not-found
+      [this key uri]
       (swap! metric-store (fn [store]
                             (assoc store key uri))))))
+
 
 (deftest recorded-metrics
   (testing "tracking success"
@@ -99,8 +118,8 @@
       (is (= 1
              (get @metric-store "test.echo.success")))
       (is (>=
-           (get @metric-store "test.echo.timing")
-           100))))
+            (get @metric-store "test.echo.timing")
+            100))))
   (testing "tracking errors"
     (let [handler (handler/build {:name "test"
                                   :endpoints {"/multiply" {:request "number/multiply/Request"
@@ -129,7 +148,7 @@
              (:status response)))
       (is (nil? (get @metric-store "test.echo.success")))
       (is (= "noooo"
-             (.getMessage (:err (first (:exceptions @metric-store))))))
+             (.getMessage ^Exception (:err (first (:exceptions @metric-store))))))
 
       (is (= 1
              (get @metric-store "test.echo.failure"))))))

--- a/test/duckula/swagger_test.clj
+++ b/test/duckula/swagger_test.clj
@@ -30,7 +30,7 @@
                                      :type "object"}
                             "ErrorMetadata" {:additionalProperties {}, :type "object"}}
               :info {:title "Swagger API: no validation", :version "0.0.1"}
-              :paths {"/SOAP/foo" {:post {:description "/SOAP/foo"
+              :paths {"/SOAP/foo" {:post {:description ":no-doc:"
                                      :parameters [{:description ""
                                                    :in "body"
                                                    :name ".SOAP.foo"

--- a/test/duckula/swagger_test.clj
+++ b/test/duckula/swagger_test.clj
@@ -19,6 +19,7 @@
              conf))))
   (testing "endpoint with no validations"
     (let [conf (swag/generate {:name "no validation"
+                               :prefix "/SOAP"
                                :endpoints {"/foo" {:handler identity}}})]
       (is (= {:consumes ["application/json"]
               :definitions {"Error" {:additionalProperties false
@@ -29,10 +30,10 @@
                                      :type "object"}
                             "ErrorMetadata" {:additionalProperties {}, :type "object"}}
               :info {:title "Swagger API: no validation", :version "0.0.1"}
-              :paths {"/foo" {:post {:description "/foo"
+              :paths {"/SOAP/foo" {:post {:description "/SOAP/foo"
                                      :parameters [{:description ""
                                                    :in "body"
-                                                   :name ".foo"
+                                                   :name ".SOAP.foo"
                                                    :required true
                                                    :schema {}}]
                                      :responses {200 {:description ":no-doc:"
@@ -41,7 +42,7 @@
                                                       :schema {:$ref "#/definitions/Error"}}
                                                  500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
                                                       :schema {:$ref "#/definitions/Error"}}}
-                                     :summary "/foo"}}}
+                                     :summary "/SOAP/foo"}}}
               :produces ["application/json"]
               :swagger "2.0"}
              conf)))))

--- a/test/duckula/swagger_test.clj
+++ b/test/duckula/swagger_test.clj
@@ -1,0 +1,49 @@
+(ns duckula.swagger-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [duckula.swagger :as swag]
+   [duckula.test.server :as test.server]))
+
+
+(deftest it-generates-a-swagger-config
+  (testing "empty endpoints"
+    (let [conf (swag/generate {:name "empty"} #_ test.server/config)]
+      (is (= {:consumes ["application/json"]
+              :definitions {}
+              :info {:title "Swagger API: empty" :version "0.0.1"}
+              :paths {}
+              :produces ["application/json"]
+              :swagger "2.0"}
+             conf))))
+  (testing "endpoint with no validations"
+    (let [conf (swag/generate {:name "no validation"
+                               :endpoints {"/foo" {:handler identity}}})]
+      (is (= {:consumes ["application/json"]
+              :definitions {"Error" {:additionalProperties false
+                                     :properties {:error {:type "string"}
+                                                  :message {:type "string"}
+                                                  :metadata {:$ref "#/definitions/ErrorMetadata"}}
+                                     :required [:message :error :metadata]
+                                     :type "object"}
+                            "ErrorMetadata" {:additionalProperties {}, :type "object"}}
+              :info {:title "Swagger API: no validation", :version "0.0.1"}
+              :paths {"/foo" {:post {:description "/foo"
+                                     :parameters [{:description ""
+                                                   :in "body"
+                                                   :name ".foo"
+                                                   :required true
+                                                   :schema {}}]
+                                     :responses {200 {:description "", :schema {}}
+                                                 410 {:description "Message with invalid schema provided"
+                                                      :schema {:$ref "#/definitions/Error"}}
+                                                 500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+                                                      :schema {:$ref "#/definitions/Error"}}}
+                                     :summary "/foo"}}}
+              :produces ["application/json"]
+              :swagger "2.0"}
+             conf)))))
+
+(deftest working-server-example-config
+  (let [conf (swag/generate test.server/config)]
+    (is (= :y
+           conf))))

--- a/test/duckula/swagger_test.clj
+++ b/test/duckula/swagger_test.clj
@@ -1,8 +1,10 @@
 (ns duckula.swagger-test
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [duckula.swagger :as swag]
-   [duckula.test.server :as test.server]))
+    [clojure.edn :as edn]
+    [clojure.java.io :as io]
+    [clojure.test :refer [deftest is testing]]
+    [duckula.swagger :as swag]
+    [duckula.test.server :as test.server]))
 
 
 (deftest it-generates-a-swagger-config
@@ -33,8 +35,9 @@
                                                    :name ".foo"
                                                    :required true
                                                    :schema {}}]
-                                     :responses {200 {:description "", :schema {}}
-                                                 410 {:description "Message with invalid schema provided"
+                                     :responses {200 {:description ":no-doc:"
+                                                      :schema {}}
+                                                 410 {:description "Request data didn't conform to the request data schema"
                                                       :schema {:$ref "#/definitions/Error"}}
                                                  500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
                                                       :schema {:$ref "#/definitions/Error"}}}
@@ -43,7 +46,12 @@
               :swagger "2.0"}
              conf)))))
 
+
+(def test-server-swagger
+  (edn/read-string (slurp (io/resource "duckula/test_swagger.edn"))))
+
+
 (deftest working-server-example-config
   (let [conf (swag/generate test.server/config)]
-    (is (= :y
+    (is (= test-server-swagger
            conf))))

--- a/test/duckula/test_swagger.edn
+++ b/test/duckula/test_swagger.edn
@@ -44,7 +44,7 @@
  :paths {"/echo" {:post {:description ":no-doc:"
                          :parameters [{:description ""
                                        :in "body"
-                                       :name ".echo"
+                                       :name "/echo"
                                        :required true
                                        :schema {}}]
                          :responses {200 {:description ":no-doc:", :schema {}}

--- a/test/duckula/test_swagger.edn
+++ b/test/duckula/test_swagger.edn
@@ -1,0 +1,96 @@
+{:consumes ["application/json"]
+ :definitions {"Error" {:additionalProperties false
+                        :properties {:error {:type "string"}
+                                     :message {:type "string"}
+                                     :metadata {:$ref "#/definitions/ErrorMetadata"}}
+                        :required [:message :error :metadata]
+                        :type "object"}
+               "ErrorMetadata" {:additionalProperties {}, :type "object"}
+               "Search.test.responseItems" {:additionalProperties false
+                                            :properties {:content {:type "string"}
+                                                         :id {:format "int64", :type "integer"}}
+                                            :required [:content :id]
+                                            :type "object"}
+               "number.multiply.Request" {:additionalProperties false
+                                          :properties {:input {:format "int64", :type "integer"}}
+                                          :required [:input]
+                                          :type "object"}
+               "number.multiply.Response" {:additionalProperties false
+                                           :properties {:message {}
+                                                        :result {:format "int64"
+                                                                 :type "integer"}
+                                                        :status {:enum ("success"
+                                                                        "error"
+                                                                        "timeout")
+                                                                 :type "string"}}
+                                           :required [:status :result :message]
+                                           :type "object"}
+               "search.test.Request" {:additionalProperties false
+                                      :properties {:order_by {:enum ("updated_at" "created_at")
+                                                              :type "string"}
+                                                   :query {:type "string"}
+                                                   :size {}}
+                                      :required [:order_by :size :query]
+                                      :type "object"}
+               "search.test.Response" {:additionalProperties false
+                                       :properties {:items {:items {:$ref "#/definitions/Search.test.responseItems"}
+                                                            :type "array"}
+                                                    :message {}
+                                                    :status {:enum ("success" "error" "timeout")
+                                                             :type "string"}}
+                                       :required [:status :items :message]
+                                       :type "object"}}
+ :info {:title "Swagger API: test-server-rpc", :version "0.0.1"}
+ :paths {"/echo" {:post {:description "/echo"
+                         :parameters [{:description ""
+                                       :in "body"
+                                       :name ".echo"
+                                       :required true
+                                       :schema {}}]
+                         :responses {200 {:description ":no-doc:", :schema {}}
+                                     410 {:description "Request data didn't conform to the request data schema"
+                                          :schema {:$ref "#/definitions/Error"}}
+                                     500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+                                          :schema {:$ref "#/definitions/Error"}}}
+                         :summary "/echo"}}
+         "/number/multiply" {:post {:description "/number/multiply"
+                                    :parameters [{:description ""
+                                                  :in "body"
+                                                  :name "number.multiply.Request"
+                                                  :required true
+                                                  :schema {:$ref "#/definitions/number.multiply.Request"}}]
+                                    :responses {200 {:description ""
+                                                     :schema {:$ref "#/definitions/number.multiply.Response"}}
+                                                410 {:description "Request data didn't conform to the request data schema"
+                                                     :schema {:$ref "#/definitions/Error"}}
+                                                500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+                                                     :schema {:$ref "#/definitions/Error"}}}
+                                    :summary "/number/multiply"}}
+         "/number/multiply-soft" {:post {:description "/number/multiply-soft"
+                                         :parameters [{:description ""
+                                                       :in "body"
+                                                       :name "number.multiply.Request"
+                                                       :required true
+                                                       :schema {:$ref "#/definitions/number.multiply.Request"}}]
+                                         :responses {200 {:description ""
+                                                          :schema {:$ref "#/definitions/number.multiply.Response"}}
+                                                     410 {:description "Request data didn't conform to the request data schema"
+                                                          :schema {:$ref "#/definitions/Error"}}
+                                                     500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+                                                          :schema {:$ref "#/definitions/Error"}}}
+                                         :summary "/number/multiply-soft"}}
+         "/search/test" {:post {:description "/search/test"
+                                :parameters [{:description ""
+                                              :in "body"
+                                              :name "search.test.Request"
+                                              :required true
+                                              :schema {:$ref "#/definitions/search.test.Request"}}]
+                                :responses {200 {:description ""
+                                                 :schema {:$ref "#/definitions/search.test.Response"}}
+                                            410 {:description "Request data didn't conform to the request data schema"
+                                                 :schema {:$ref "#/definitions/Error"}}
+                                            500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
+                                                 :schema {:$ref "#/definitions/Error"}}}
+                                :summary "/search/test"}}}
+ :produces ["application/json"]
+ :swagger "2.0"}

--- a/test/duckula/test_swagger.edn
+++ b/test/duckula/test_swagger.edn
@@ -41,7 +41,7 @@
                                        :required [:status :items :message]
                                        :type "object"}}
  :info {:title "Swagger API: test-server-rpc", :version "0.0.1"}
- :paths {"/echo" {:post {:description "/echo"
+ :paths {"/echo" {:post {:description ":no-doc:"
                          :parameters [{:description ""
                                        :in "body"
                                        :name ".echo"
@@ -53,7 +53,7 @@
                                      500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
                                           :schema {:$ref "#/definitions/Error"}}}
                          :summary "/echo"}}
-         "/number/multiply" {:post {:description "/number/multiply"
+         "/number/multiply" {:post {:description ""
                                     :parameters [{:description ""
                                                   :in "body"
                                                   :name "number.multiply.Request"
@@ -66,7 +66,7 @@
                                                 500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
                                                      :schema {:$ref "#/definitions/Error"}}}
                                     :summary "/number/multiply"}}
-         "/number/multiply-soft" {:post {:description "/number/multiply-soft"
+         "/number/multiply-soft" {:post {:description ""
                                          :parameters [{:description ""
                                                        :in "body"
                                                        :name "number.multiply.Request"
@@ -79,7 +79,7 @@
                                                      500 {:description "Internal server error, or response couldn't be serialized according to the response schema"
                                                           :schema {:$ref "#/definitions/Error"}}}
                                          :summary "/number/multiply-soft"}}
-         "/search/test" {:post {:description "/search/test"
+         "/search/test" {:post {:description "Find all matching documents and specify the order"
                                 :parameters [{:description ""
                                               :in "body"
                                               :name "search.test.Request"


### PR DESCRIPTION
This is hacky as hell, but it works, at least with the test server config attached as well one of our own production services (*redacted*)

We go: Avro -> Prismatic Schema -> Swagger 

By converting Duckula's route map + Avro schemas, to format digestible by [ring-swagger](https://github.com/metosin/ring-swagger), and then we bundle swagger-ui and make it available under `/~docs/ui`

![CleanShot 2020-05-23 at 13 54 16](https://user-images.githubusercontent.com/104818/82740369-03a49c80-9cfd-11ea-9665-fc8e104d554b.gif)

# Notes

This is a proof of concept - I think it's better to extract this into a separate library, and have it conditionally included/enabled as it brings libraries not necessarily useful in pure API building context (Schema for example).

So once this is :ok:d and tested with one of our production apps, I'll move ahead with a new repo + maven artifact


# Bonus points

Schemas can be defined inline in the config, and don't have to be loaded from `.avsc` files. Example:


```clojure

{:name "test"
 :endpoints  {"/foo" {:handler some/handler
                      :request {:type "record"
                                :name "SomeRequest"
                                :fields [{:name "hello" :type "string"}]}
                      :response {:type "record"
                                 :name "SomeRequest"
                                 :fields [{:name "world" :type "string"}]}}}}


```