### PR TITLE
catch throwable (asserts)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/duckula "0.7.2-SNAPSHOT"
+(defproject nomnom/duckula "0.7.2"
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/duckula "0.7.1"
+(defproject nomnom/duckula "0.7.2-SNAPSHOT"
   :description "RPC server (and soon, client), built on top of JSON+Avro+HTTP"
   :url "https://github.com/nomnom-insights/nomnom.duckula"
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/src/duckula/handler.clj
+++ b/src/duckula/handler.clj
@@ -127,7 +127,7 @@ It depends on a component implementing  duckula.prococol/Monitoring protocol
                   (monitoring/on-success monitoring success-key {:body body :status status})
                   (monitoring/on-error monitoring error-key))
                 response)
-              (catch Exception err
+              (catch Throwable err
                 (monitoring/on-failure monitoring failure-key)
                 (let [{:keys [validation-type] :as metadata} (ex-data err)
                       to-report (merge


### PR DESCRIPTION
Ensure we can catch `assert` and `pre/post` errors and report them via monitoring middleware